### PR TITLE
fix: prevent zombie pw-record accumulation in voxtype-record

### DIFF
--- a/voxtype/voxtype-record
+++ b/voxtype/voxtype-record
@@ -72,7 +72,9 @@ case "${1:-}" in
     toggle)
         state=$(cat "$STATE_FILE" 2>/dev/null || echo "idle")
         if [ "$state" = "idle" ]; then
-            # About to start — begin independent audio capture
+            # Clean up any orphaned pw-record from previous sessions
+            stop_pw_record
+            # Begin independent audio capture
             timestamp=$(date +%Y-%m-%dT%H-%M-%S)
             recording_file="$RECORDINGS_DIR/$timestamp.wav"
             pw-record --rate=16000 --channels=1 --format=s16 \


### PR DESCRIPTION
## Summary

- Calls `stop_pw_record()` before spawning a new `pw-record` in the START path, killing any orphaned process from a previous session where `voxtype record toggle` failed after `pw-record` was already running.

## Problem

When `voxtype-record toggle` starts a recording, it spawns `pw-record` in the background and saves its PID to a file. If the subsequent `voxtype record toggle` call fails (e.g., daemon error), the pw-record process is orphaned — but its PID is still in the file. The next recording start overwrites the PID file, permanently losing track of the old process.

Each leaked `pw-record` records indefinitely, growing multi-GB WAV files. Found 47 zombie processes accumulating ~60 GB of silence over 2 weeks.

## Fix

Add a defensive `stop_pw_record()` call at the top of the START path. Since the PID file still contains the orphan's PID at this point (before being overwritten), the kill succeeds and the orphan is cleaned up.